### PR TITLE
Add Projection enum to camera

### DIFF
--- a/src/scene/camera.rs
+++ b/src/scene/camera.rs
@@ -1,5 +1,5 @@
 use cgmath::*;
-use gltf::camera::Projection;
+use gltf::camera::Projection as GltfProjection;
 
 /// Contains camera properties.
 #[derive(Clone, Debug)]
@@ -7,14 +7,41 @@ pub struct Camera {
     /// Transform matrix (also called world to camera matrix)
     pub transform: Matrix4<f32>,
 
-    /// Angle in degree of field of view
-    pub fov: Rad<f32>,
+    /// Projection type and specific parameters
+    pub projection: Projection,
 
     /// The distance to the far clipping plane.
+    ///
+    /// For perspective projection, this may be infinite.
     pub zfar: f32,
 
     /// The distance to the near clipping plane.
     pub znear: f32,
+}
+
+/// Camera projections
+#[derive(Debug, Clone)]
+pub enum Projection {
+    /// Perspective projection
+    Perspective {
+        /// Y-axis FOV, in radians
+        fovy: Rad<f32>,
+        /// Aspect ratio, if specified
+        aspect_ratio: Option<f32>,
+    },
+    /// Orthographic projection
+    Orthographic {
+        /// Projection scale
+        scale: Vector2<f32>,
+    },
+}
+impl Default for Projection {
+    fn default() -> Self {
+        Self::Perspective {
+            fovy: Rad(0.399),
+            aspect_ratio: None,
+        }
+    }
 }
 
 impl Camera {
@@ -76,14 +103,20 @@ impl Camera {
         let mut cam = Self::default();
         cam.transform = transform.clone();
         match gltf_cam.projection() {
-            Projection::Orthographic(ortho) => {
+            GltfProjection::Orthographic(ortho) => {
+                cam.projection = Projection::Orthographic {
+                    scale: Vector2::new(ortho.xmag(), ortho.ymag()),
+                };
                 cam.zfar = ortho.zfar();
                 cam.znear = ortho.znear();
             }
-            Projection::Perspective(pers) => {
+            GltfProjection::Perspective(pers) => {
+                cam.projection = Projection::Perspective {
+                    fovy: Rad(pers.yfov()),
+                    aspect_ratio: pers.aspect_ratio(),
+                };
                 cam.zfar = pers.zfar().unwrap_or(f32::INFINITY);
                 cam.znear = pers.znear();
-                cam.fov = Rad(pers.yfov());
             }
         };
         cam
@@ -94,7 +127,7 @@ impl Default for Camera {
     fn default() -> Self {
         Camera {
             transform: Zero::zero(),
-            fov: Rad(0.399),
+            projection: Projection::default(),
             zfar: f32::INFINITY,
             znear: 0.,
         }

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -7,7 +7,7 @@ pub mod model;
 
 use crate::utils::transform_to_matrix;
 use crate::GltfData;
-pub use camera::Camera;
+pub use camera::{Camera, Projection};
 pub use light::Light;
 pub use model::{Material, Model};
 


### PR DESCRIPTION
Currently the Camera is missing some info needed for rendering. This adds a Projection enum
that stores more info.