### PR TITLE
Add Send + Sync bound to load result.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub use scene::*;
 /// #   Ok(())
 /// # }
 /// ```
-pub fn load<P>(path: P) -> Result<Vec<Scene>, Box<dyn Error>>
+pub fn load<P>(path: P) -> Result<Vec<Scene>, Box<dyn Error + Send + Sync>>
 where
     P: AsRef<Path>,
 {


### PR DESCRIPTION
Hello! Thank you for making this crate, I have been using it to make a game for the past several months.

I integrated the [anyhow]() crate into my project, and after reading [this](https://github.com/dtolnay/anyhow/issues/83) thread I learned I needed to convert the Box<dyn Error> returned by [easy_gltf::load](https://github.com/flomonster/easy-gltf/blob/774ae2fb704f6b2089bea66377c6f1e6f2f3b03d/src/lib.rs#L62) by adding the `Sync + Send` bounds to allow the conversion to happen. 

With this change I am now able to convert the `Box<dyn std::error::Error>` returned from `easy_gltf::load` into a `anyhow::Result<T, E>`

```rust
let scenes = easy_gltf::load(path).map_err(|e| anyhow!(e))?;
```

Without this change I am unable to figure out another way. I've only been using rust for a few months now, so it's totally possible I don't understand something. Thanks