### PR TITLE
add projection enum to camera

### DIFF
--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -7,7 +7,7 @@ pub mod model;
 
 use crate::utils::transform_to_matrix;
 use crate::GltfData;
-pub use camera::Camera;
+pub use camera::{Camera, Projection};
 pub use light::Light;
 pub use model::{Material, Model};
 


### PR DESCRIPTION
Currently the Camera is missing some info needed for rendering. This adds a Projection enum that stores more info.