### PR TITLE
Bump image to 0.25.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,5 @@ extras = ["gltf/extras"]
 [dependencies]
 cgmath = "0.18.0"
 gltf = { version = "1.3.0", features = ["KHR_lights_punctual"] }
-image = "0.24.7"
+image = "0.25.0"
 base64 = "0.21.5"


### PR DESCRIPTION
I made a similar PR for `gltf` as well to ensure compatibility. See https://github.com/gltf-rs/gltf/pull/414